### PR TITLE
refactor!(postgres): allow string types for port

### DIFF
--- a/nix/postgres.nix
+++ b/nix/postgres.nix
@@ -99,8 +99,8 @@ in
     };
 
     port = lib.mkOption {
-      type = lib.types.port;
-      default = 5432;
+      type = lib.types.str;
+      default = "5432";
       description = ''
         The TCP port to accept connections.
       '';
@@ -143,7 +143,6 @@ in
         '';
         default = {
           listen_addresses = config.listen_addresses;
-          port = config.port;
           unix_socket_directories = config.dataDir;
           hba_file = "${config.hbaConfFile}";
         };
@@ -163,7 +162,6 @@ in
         '';
         default = {
           listen_addresses = config.listen_addresses;
-          port = config.port;
           unix_socket_directories = lib.mkDefault config.dataDir;
           hba_file = "${config.hbaConfFile}";
         };
@@ -383,12 +381,14 @@ in
                     set -x
                     PGDATA=$(readlink -f "${config.dataDir}")
                     export PGDATA
-                    postgres -k "$PGDATA"
+                    PGPORT=${config.port}
+                    export PGPORT
+                    postgres -k "$PGDATA" -p "$PGPORT"
                   '';
                 };
                 pg_isreadyArgs = [
                   "-h $(readlink -f ${config.dataDir})"
-                  "-p ${toString config.port}"
+                  "-p ${config.port}"
                   "-d template1"
                 ] ++ (lib.optional (config.superuser != null) "-U ${config.superuser}");
               in


### PR DESCRIPTION
The port was previously specified using the port type, but this does not allow for any flexibility for the port by the end-user. This means that running the service in multiple projects would have conflicts if the port wasn't unique among them. By allowing for a string type, the port can be controlled by an environment variable and therefore it is possible to use the service multiple times without everyone agreeing on unique ports.